### PR TITLE
First draft

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,12 @@
+image: clever/drone-go:1.5
+notify:
+  email:
+    recipients:
+    - drone@clever.com
+  slack:
+    on_failure: true
+    on_started: false
+    on_success: false
+    webhook_url: $$slack_webhook
+script:
+- make test

--- a/.drone.yml
+++ b/.drone.yml
@@ -9,4 +9,5 @@ notify:
     on_success: false
     webhook_url: $$slack_webhook
 script:
+- go get github.com/stretchr/testify/assert
 - make test

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+example/example

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 PKGS := $(shell go list ./... | grep -v example)
+GOLINT := $(GOPATH)/bin/golint
 .PHONY: all test
 
 GOVERSION := $(shell go version | grep 1.5)
@@ -6,10 +7,6 @@ ifeq "$(GOVERSION)" ""
   $(error must be running Go version 1.5)
 endif
 export GO15VENDOREXPERIMENT = 1
-
-GOLINT := $(GOPATH)/bin/golint
-$(GOLINT):
-	go get github.com/golang/lint/golint
 
 all: test
 
@@ -27,3 +24,6 @@ $(PKGS): $(GOLINT)
 	@echo "TESTING..."
 	@TEST_MONGO_URL=$(TEST_MONGO_URL) go test -v $@
 	@echo ""
+
+$(GOLINT):
+	go get github.com/golang/lint/golint

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,29 @@
+PKGS := $(shell go list ./... | grep -v example)
+.PHONY: all test
+
+GOVERSION := $(shell go version | grep 1.5)
+ifeq "$(GOVERSION)" ""
+  $(error must be running Go version 1.5)
+endif
+export GO15VENDOREXPERIMENT = 1
+
+GOLINT := $(GOPATH)/bin/golint
+$(GOLINT):
+	go get github.com/golang/lint/golint
+
+all: test
+
+test: $(PKGS)
+
+$(PKGS): $(GOLINT)
+	@echo "FORMATTING..."
+	@gofmt -w=true $(GOPATH)/src/$@/*.go
+	@echo "LINTING..."
+	@$(GOLINT) $(GOPATH)/src/$@/*.go
+	@echo ""
+	@echo "VETTING..."
+	@go vet $(GOPATH)/src/$@/*.go
+	@echo ""
+	@echo "TESTING..."
+	@TEST_MONGO_URL=$(TEST_MONGO_URL) go test -v $@
+	@echo ""

--- a/README.md
+++ b/README.md
@@ -36,9 +36,6 @@ Usage of ./example:
 ./example -district_id="abc123"
 > config: {DistrictID:abc123 Collection:}
 
-./example -district_id="abc123" -collection="schools"
-> config: {DistrictID:abc123 Collection:schools}
-
 ./example '{"district_id":"abc123","collection":"schools"}'
 > config: {DistrictID:abc123 Collection:schools}
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,55 @@
 # configure
+
+Easily fill in a configuration struct with either flag arguments or a JSON blob argument.
+
+
+## usage
+
+Given a simple program that uses two arguments, `district_id` and `collection`:
+
+```go
+var config struct {
+	DistrictID string `config:"district_id,required"`
+	Collection string `config:"collection"`
+}
+
+func main() {
+	if err := configure.Configure(&config); err != nil {
+		log.Fatalf("err: %#v", err)
+	}
+	log.Printf("config: %#v", config)
+
+	// go use arguments to do something
+}
+```
+
+It can be invoked two styles:
+
+```bash
+./example -h
+Usage of ./example:
+  -collection string
+      generated field
+  -district_id string
+      generated field
+
+./example -district_id="abc123"
+> config: {DistrictID:abc123 Collection:}
+
+./example -district_id="abc123" -collection="schools"
+> config: {DistrictID:abc123 Collection:schools}
+
+./example '{"district_id":"abc123","collection":"schools"}'
+> config: {DistrictID:abc123 Collection:schools}
+
+./example -district_id="abc123" -collection="schools"
+> config: {DistrictID:abc123 Collection:schools}
+
+# fails when not provided with the required district_id argument
+./example -collection=schools
+> err: Missing required fields: [district_id]
+
+./example '{"collection":"schools"}'
+> err: Missing required fields: [district_id]
+```
+

--- a/configure.go
+++ b/configure.go
@@ -78,7 +78,7 @@ func Configure(configStruct interface{}) error {
 
 		// currently we only support strings
 		typedAttr := config.Type().Field(i)
-		if typedAttr.Type.Name() != "string" {
+		if typedAttr.Type.Kind() != reflect.String {
 			return ErrStringsOnly
 		}
 
@@ -107,7 +107,7 @@ func Configure(configStruct interface{}) error {
 		}
 	}
 
-	// if no flags were found and we have a value in
+	// if no flags were found and we have a value in the first arg, we try to parse JSON from it.
 	if !flagFound && configFlags.Arg(0) != "" {
 		jsonValues := map[string]string{}
 		if err := json.NewDecoder(bytes.NewBufferString(configFlags.Arg(0))).Decode(&jsonValues); err != nil {

--- a/configure.go
+++ b/configure.go
@@ -22,7 +22,7 @@ var (
 	ErrNotReference           = errors.New("The config struct must be a pointer.")
 	ErrStructOnly             = errors.New("Config object must be a struct.")
 	ErrNoTagValue             = errors.New("Config object attributes must have a 'config' tag value.")
-	ErrFlagParsed             = errors.New("Flags should not be used in conjuction, do not flag.Parse() before Configure")
+	ErrFlagParsed             = errors.New("The flag library cannot be used in conjunction with configure")
 	ErrInvalidJSON            = errors.New("Invalid JSON found in arguments.")
 	ErrStructTagInvalidOption = errors.New("Only 'required' is a config option.")
 )

--- a/configure.go
+++ b/configure.go
@@ -1,0 +1,135 @@
+package configure
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+const (
+	structTagKey   = "config"
+	requiredTagKey = "required"
+)
+
+var (
+	ErrStringsOnly            = errors.New("Only string values are allowed in a config struct.")
+	ErrNotReference           = errors.New("The config struct must be a pointer.")
+	ErrStructOnly             = errors.New("Config object must be a struct.")
+	ErrNoTagValue             = errors.New("Config object attributes must have a 'config' tag value.")
+	ErrFlagParsed             = errors.New("Flags should not be used in conjuction, do not flag.Parse() before Configure")
+	ErrInvalidJSON            = errors.New("Invalid JSON found in arguments.")
+	ErrStructTagInvalidOption = errors.New("Only 'required' is a config option.")
+)
+
+func parseTagKey(tag string) (key string, required bool, err error) {
+	s := strings.Split(tag, ",")
+	switch len(s) {
+	case 2:
+		if s[1] != "required" {
+			return "", false, ErrStructTagInvalidOption
+		}
+		return s[0], true, nil
+	case 1:
+		return s[0], false, nil
+	default:
+		return "", false, ErrNoTagValue
+	}
+}
+
+func Configure(config interface{}) error {
+	if flag.Parsed() {
+		return ErrFlagParsed
+	}
+
+	val2 := reflect.ValueOf(config)
+	if val2.Kind() != reflect.Ptr {
+		return ErrStructOnly
+	}
+
+	values := map[string]*string{}
+	flagFound := false
+	requiredFields := false
+	missingRequiredFields := []string{}
+
+	val := val2.Elem()
+	for i := 0; i < val.NumField(); i++ {
+		valueField := val.Field(i)
+		if !valueField.CanSet() {
+			return ErrNotReference
+		}
+
+		typeField := val.Type().Field(i)
+		if typeField.Type.Name() != "string" {
+			return ErrStringsOnly
+		}
+
+		tagVal, required, err := parseTagKey(typeField.Tag.Get(structTagKey))
+		if err != nil {
+			return err
+		} else if required {
+			requiredFields = true
+		}
+
+		values[tagVal] = flag.String(tagVal, "", "generated field")
+	}
+	flag.Parse()
+
+	for i := 0; i < val.NumField(); i++ {
+		valueField := val.Field(i)
+		tagVal, _, err := parseTagKey(val.Type().Field(i).Tag.Get(structTagKey))
+		if err != nil {
+			return err
+		}
+
+		if *values[tagVal] != "" {
+			flagFound = true
+			valueField.SetString(*values[tagVal])
+		}
+	}
+
+	if !flagFound && flag.Arg(0) != "" {
+		jsonValues := map[string]string{}
+		if err := json.NewDecoder(bytes.NewBufferString(flag.Arg(0))).Decode(&jsonValues); err != nil {
+			return ErrInvalidJSON
+		}
+
+		for i := 0; i < val.NumField(); i++ {
+			valueField := val.Field(i)
+			tagVal, _, err := parseTagKey(val.Type().Field(i).Tag.Get(structTagKey))
+			if err != nil {
+				return err
+			}
+
+			if jsonValues[tagVal] != "" {
+				valueField.SetString(jsonValues[tagVal])
+			}
+		}
+	}
+
+	// validate that all required fields were set
+	if requiredFields {
+		for i := 0; i < val.NumField(); i++ {
+			valueField := val.Field(i)
+			typeField := val.Type().Field(i)
+			if typeField.Type.Name() != "string" {
+				return ErrStringsOnly
+			}
+
+			tagKey, required, err := parseTagKey(typeField.Tag.Get(structTagKey))
+			if err != nil {
+				return err
+			} else if required && valueField.String() == "" {
+				missingRequiredFields = append(missingRequiredFields, tagKey)
+			}
+		}
+		if len(missingRequiredFields) > 0 {
+			return fmt.Errorf("Missing required fields: %s", missingRequiredFields)
+		}
+	}
+
+	return nil
+}

--- a/configure_test.go
+++ b/configure_test.go
@@ -1,0 +1,91 @@
+package configure
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	expectedDistrict   = "abc123"
+	expectedCollection = "schools"
+)
+
+var (
+	errMissingDistrictField = fmt.Errorf(missingValuesErrTemplate, []string{"district_id"})
+)
+
+func TestConfigure(t *testing.T) {
+	for _, spec := range []struct {
+		context    string
+		args       []string
+		err        error
+		district   string
+		collection string
+	}{
+		{
+			context:  "normal case w/ flags",
+			args:     []string{"-district_id=abc123"},
+			district: expectedDistrict,
+		},
+		{
+			context: "missing required field",
+			err:     errMissingDistrictField,
+		},
+		{
+			context: "given other field but not required field",
+			args:    []string{"-collection=schools"},
+			err:     errMissingDistrictField,
+		},
+		{
+			context:  "normal case w/ json",
+			args:     []string{`{"district_id":"abc123"}`},
+			district: expectedDistrict,
+		},
+		{
+			context:    "json w/ all fields",
+			args:       []string{`{"district_id":"abc123","collection":"schools"}`},
+			district:   expectedDistrict,
+			collection: expectedCollection,
+		},
+		{
+			context: "empty JSON blob",
+			err:     errMissingDistrictField,
+		},
+		{
+			context: "only evaluates flags if provided first",
+			args:    []string{"-collection=schools", `{"district_id":"abc123"}`},
+			err:     errMissingDistrictField,
+		},
+		{
+			context: "only evaluates flags if provided first",
+			args:    []string{"-collection=schools", `{"district_id":"abc123"}`},
+			err:     errMissingDistrictField,
+		},
+		{
+			context: "fails with non-declared flags",
+			args:    []string{"-district_id=abc123", "-random-test-flag=X"},
+			err:     errors.New("flag provided but not defined: -random-test-flag"),
+		},
+	} {
+		// NOTE: we override both the os.Args and flag.Commandline variables to allow
+		// repeated calls to the flag library.
+		os.Args = append([]string{"test"}, spec.args...)
+		flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
+
+		var config struct {
+			DistrictID string `config:"district_id,required"`
+			Collection string `config:"collection"`
+		}
+		if spec.err == nil && assert.NoError(t, Configure(&config), "Case '%s'", spec.context) {
+			assert.Equal(t, spec.district, config.DistrictID, "Case '%s'", spec.context)
+			assert.Equal(t, spec.collection, config.Collection, "Case '%s'", spec.context)
+		} else {
+			assert.Equal(t, spec.err, Configure(&config), "Case '%s'", spec.context)
+		}
+	}
+}

--- a/configure_test.go
+++ b/configure_test.go
@@ -116,3 +116,14 @@ func TestFailOnTooManyTagValues(t *testing.T) {
 	}
 	assert.Equal(t, ErrTooManyTagValues, Configure(&config))
 }
+
+func TestBlankFlagValues(t *testing.T) {
+	var config struct {
+		DistrictID string `config:"district_id"`
+		Collection string `config:"collection"`
+	}
+
+	os.Args = []string{"test", "-collection=", "-district_id="}
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
+	assert.NoError(t, Configure(&config))
+}

--- a/example/main.go
+++ b/example/main.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"log"
+
+	"github.com/Clever/configure"
+)
+
+var config struct {
+	DistrictID string `config:"district_id,required"`
+	Collection string `config:"collection"`
+}
+
+func main() {
+	if err := configure.Configure(&config); err != nil {
+		log.Fatalf("err: %s", err)
+	}
+	log.Printf("config: %+v", config)
+}


### PR DESCRIPTION
This is the first draft of a simple configuration wrapper around the `flag` library and a JSON argument. The intention is to allow use of flag arguments by humans and easily support JSON blob arguments when the robots are creating the jobs.

Currently there is only support for string arguments. I intend to add support for boolean arguments. Other types will potentially be added as needed.

---

CC @rgarcia @peggyl @cgclever @azylman @cozmo
